### PR TITLE
Fix /home not rendering

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -82,12 +82,9 @@ def upload():
 
 
 @app.route('/overshare')
-@login_required
-def overshare_self():
-  return overshare(current_user.username)
-
-
 @app.route('/overshare/<username>')
 @login_required
-def overshare(username):
+def overshare(username=None):
+  if username is None:
+    username = current_user.username
   return render_template('overshare.html', title='Overshare', username=username)


### PR DESCRIPTION
`url_for('overshare')` calls the `overshare()` route in routes.py, but since it expects a `username` argument, not providing one caused the server to throw an error. This fix gives `username` a default value.